### PR TITLE
implement retry of select discord API calls

### DIFF
--- a/slack2discord/client.py
+++ b/slack2discord/client.py
@@ -121,12 +121,12 @@ class DiscordClient(discord.Client):
                 await discord_obj.discord_func(arg1, arg2)
 
         """
-        message_sent = False
+        coro_called = False
         retry_count = 0
-        while not message_sent:
+        while not coro_called:
             try:
                 ret = await coro(*args, **kwargs)
-                message_sent = True
+                coro_called = True
                 return ret
             except Exception as e:
                 retry_count += 1

--- a/slack2discord/client.py
+++ b/slack2discord/client.py
@@ -204,8 +204,8 @@ class DiscordClient(discord.Client):
     #     return wrapper
 
     @decorator
-    async def discord_retry(coro, *args, **kwargs):
-        logger.info(f"XXX begin discord_retry(), args={args} kwargs={kwargs}")
+    async def discord_retry(coro, what="foo", *args, **kwargs):
+        logger.info(f"XXX begin discord_retry(), what={what} args={args} kwargs={kwargs}")
 
         async def retry(retry_sec):
             logger.info(f"XXX sleep {retry_sec} sec")
@@ -214,6 +214,7 @@ class DiscordClient(discord.Client):
         message_sent = False
         while not message_sent:
             try:
+                logger.info(f"XXX we are {what}")
                 ret = await coro(*args, **kwargs)
                 message_sent = True
                 logger.info("XXX end discord_retry()")
@@ -264,7 +265,7 @@ class DiscordClient(discord.Client):
     #     await self.discord_retry(channel.send(msg))
     #     logger.info("XXX end send_message")
 
-    @discord_retry
+    @discord_retry(what="sending message")
     async def send_msg(self, channel, msg):
         logger.info(f"XXX begin send_message, channel={channel} msg={msg}")
         await channel.send(msg)

--- a/slack2discord/client.py
+++ b/slack2discord/client.py
@@ -121,6 +121,10 @@ class DiscordClient(discord.Client):
                 await discord_obj.discord_func(arg1, arg2)
 
         """
+        # seconds to wait on subsequent retries
+        # not used in the rate limiting case, where the retry is explicitly provided
+        retry_backoff = [1, 5, 30]
+
         coro_called = False
         retry_count = 0
         while not coro_called:
@@ -144,7 +148,8 @@ class DiscordClient(discord.Client):
                         exc_msg = "Caught HTTP exception"
                     else:
                         exc_msg = "Caught non-HTTP exception"
-                    retry_sec = 5
+                    retry_idx = min(retry_count - 1, len(retry_backoff) - 1)
+                    retry_sec = retry_backoff[retry_idx]
 
                 logger.warn(f"{exc_msg} {desc}: {e}")
                 logger.info(f"Will retry #{retry_count} after {retry_sec} seconds, press Ctrl-C to abort")

--- a/slack2discord/client.py
+++ b/slack2discord/client.py
@@ -71,9 +71,6 @@ class DiscordClient(discord.Client):
                 return
 
             for timestamp in sorted(self.parsed_messages.keys()):
-                # XXX to help test failures, slow this down
-                logger.info("XXX Waiting 1 sec to slow things down for testing failures")
-                await asyncio.sleep(1)
                 (message, thread) = self.parsed_messages[timestamp]
                 sent_message = await self.send_msg_to_channel(channel, message)
                 logger.info(f"Message posted: {timestamp}")
@@ -81,9 +78,6 @@ class DiscordClient(discord.Client):
                 if thread:
                     created_thread = await self.create_thread(sent_message, f"thread{timestamp}")
                     for timestamp_in_thread in sorted(thread.keys()):
-                        # XXX to help test failures, slow this down
-                        logger.info("XXX Waiting 1 sec to slow things down for testing failures")
-                        await asyncio.sleep(1)
                         thread_message = thread[timestamp_in_thread]
                         await self.send_msg_to_thread(created_thread, thread_message)
                         logger.info(f"Message in thread posted: {timestamp_in_thread}")

--- a/slack2discord/client.py
+++ b/slack2discord/client.py
@@ -206,8 +206,9 @@ class DiscordClient(discord.Client):
     @decorator
     async def discord_retry(coro, *args, **kwargs):
         logger.info(f"XXX begin discord_retry(), args={args} kwargs={kwargs}")
-        await coro(*args, **kwargs)
+        ret = await coro(*args, **kwargs)
         logger.info("XXX end discord_retry()")
+        return ret
 
     # @discord_retry
     # async def send_msg(self, channel, msg):


### PR DESCRIPTION
when wrapped with the `@discord_retry` decorator

In the event of failure (e.g. getting rate limited by the server, HTTP exceptions, any
other exceptions), will retry indefinitely until successful.

This is not strictly the correct thing to do in all scenarios. But it's a lot more
difficult to try to differentiate what failures should and not should not retry, so leave
it up to the user to press Ctrl-C to manually cancel if they do not want to retry.

It might be best to only wrap calls that are made repeatedly. If all the setup is done
earlier, when instantiating the discord.Client, that could catch a substantial class of
failures for which retry might not be applicable.

Note that I have been unable to recreate a 429 (Rate Limited) in practice, but the code supports it.

For simplicity, I am using the decorator package, which adds one more requirement to the virtualenv.
https://pypi.org/project/decorator/
https://github.com/micheles/decorator/blob/master/docs/documentation.md