### PR TITLE
provide channel name rather than id

### DIFF
--- a/slack2discord.py
+++ b/slack2discord.py
@@ -24,19 +24,19 @@ if __name__ == '__main__':
 
     # XXX eventually do real arg parsing
     if len(argv) != 4:
-        print(f"Usage {argv[0]} <token> <filename> <channel_id>")
+        print(f"Usage {argv[0]} <token> <filename> <channel>")
         exit(1)
 
     token = argv[1]
     filename = argv[2]
-    channel_id = int(argv[3])
+    channel = argv[3]
     # XXX this should be an arg, for now just edit here
     verbose = False
 
     parser = SlackParser(verbose)
     parser.parse_json_slack_export(filename)
 
-    client = DiscordClient(token, channel_id, parser.parsed_messages, verbose)
+    client = DiscordClient(token, channel, parser.parsed_messages, verbose)
     # if Ctrl-C is pressed, we do *not* get a KeyboardInterrupt b/c it is caught by the run() loop in the discord client
     client.run()
 

--- a/slack2discord/client.py
+++ b/slack2discord/client.py
@@ -73,7 +73,7 @@ class DiscordClient(discord.Client):
                 return
 
             if len(channels) > 1:
-                logger.warn(f"Found multiple channel id's with the same name '{self.channel}': {channel_ids}")
+                logger.warn(f"Found multiple channels with the same name '{self.channel}': id {channel_ids}")
                 logger.info("Will arbitrarily pick the first")
 
             channel = channels[0]


### PR DESCRIPTION
this is much more user friendly
you don't have to enable developer mode and right click in the GUI

use discord.Client.get_all_channels()
then iterate through all and find the one with the matching .name there should only be 1
if there are more than 1, arbitrarily pick the first

we expect this to be a TextChannel
if it's not, just warn, but keep going

no longer calling discord.Client.get_channel(id)
but it's the same intent needed (guilds=True) for both that and get_all_channels()