### PR TITLE
implement importing an entire channel at once

### DIFF
--- a/slack2discord.py
+++ b/slack2discord.py
@@ -46,5 +46,6 @@ if __name__ == '__main__':
     client.run()
 
     # XXX return values of asyncio functions are tricky, don't worry about it for now
+    #     we could set a boolean on success within the client
     logger.info("Discord import from Slack export complete (may or may not have been successful)")
     exit(0)

--- a/slack2discord.py
+++ b/slack2discord.py
@@ -26,17 +26,23 @@ if __name__ == '__main__':
     config = get_config(argv)
 
     # XXX this is a WIP
-    if config.src_dir:
-        raise NotImplementedError("--src_dir (one channel) not yet implemented")
     if config.src_dirtree:
         raise NotImplementedError("--src_dirtree (multiple channels) not yet implemented")
 
-    parser = SlackParser(config.verbose)
-    parser.parse_json_slack_export(config.src_file)
+    # parse either a single file (one day of one Slack channel),
+    # or all of the files in a dir (all days for one Slack channel)
+    parser = SlackParser(
+        src_file=config.src_file,
+        src_dir=config.src_dir,
+        dest_channel=config.dest_channel,
+        verbose=config.verbose)
+    parser.parse()
 
-    client = DiscordClient(config.token, config.dest_channel, parser.parsed_messages,
+    # post the parsed messages to a Discord channel
+    client = DiscordClient(config.token, parser.dest_channel, parser.parsed_messages,
                            verbose=config.verbose, dry_run=config.dry_run)
-    # if Ctrl-C is pressed, we do *not* get a KeyboardInterrupt b/c it is caught by the run() loop in the discord client
+    # if Ctrl-C is pressed, we do *not* get a KeyboardInterrupt
+    # b/c it is caught by the run() loop in the discord client
     client.run()
 
     # XXX return values of asyncio functions are tricky, don't worry about it for now

--- a/slack2discord/client.py
+++ b/slack2discord/client.py
@@ -74,6 +74,8 @@ class DiscordClient(discord.Client):
             if not channels:
                 logger.error(f"Unable to find channel '{self.channel_name}'")
                 logger.warn("Will NOT be able to post messages")
+                # XXX need to think more about error handling.
+                #     should we raise RuntimeError in this case?
                 return
 
             if len(channels) > 1:
@@ -97,10 +99,15 @@ class DiscordClient(discord.Client):
                         await self.send_msg_to_thread(created_thread, thread_message)
                         logger.info(f"Message in thread posted: {timestamp_in_thread}")
 
+            # XXX maybe set a boolean to indicate success to the caller,
+            #     if actual return values are hard?
             logger.info("Done posting messages")
         except Exception as e:
             # Ideally this shouldn't happen
             # But when it does, esp. during development, this is helpful for debugging problems
+            # XXX need to think more about error handling.
+            #     should we be swallowing the exception, or passing it up,
+            #     or at least in some way communicating success or failure to the caller
             logger.error(f"Caught exception posting messages: {e}")
             print_exc()
         finally:

--- a/slack2discord/parser.py
+++ b/slack2discord/parser.py
@@ -1,6 +1,9 @@
 from datetime import datetime
 import json
 import logging
+from os import listdir
+from os.path import basename, join
+from re import match
 import time
 
 
@@ -12,9 +15,21 @@ class SlackParser():
     A parser for exported files from Slack
     to interpret the content of messages to post to Discord
     """
-    def __init__(self, verbose):
+    def __init__(self, src_file=None, src_dir=None, dest_channel=None, verbose=False):
+        self.src_file = src_file
+        self.src_dir = src_dir
+        self.dest_channel = dest_channel
         self.verbose = verbose
         self.parsed_messages = dict()
+
+    @staticmethod
+    def is_slack_export_filename(filename):
+        """
+        Check if the given filename is of the form expected for a slack export JSON file
+
+        In practice, these should be of the form YYYY-MM-DD.json
+        """
+        return match('\A\d\d\d\d-\d\d-\d\d.json\Z', basename(filename))
 
     @staticmethod
     def format_time(timestamp):
@@ -41,9 +56,46 @@ class SlackParser():
         else:
             return f"`{SlackParser.format_time(timestamp)}`{message_sep}{message}"
 
-    def parse_json_slack_export(self, filename):
+    def parse(self):
         """
-        Parse a JSON file that contains the exported messages from a slack channel
+        Parse a Slack export.
+
+        Whether this is a single file, or an entire dir, depends on the configuration that was
+        passed in during initialization.
+        """
+        if self.src_dir:
+            self.parse_channel(self.src_dir)
+        elif self.src_file:
+            self.parse_file(self.src_file)
+        else:
+            logger.error("Neither src dir nor file set, will not parse")
+
+    def parse_channel(self, channel_dir):
+        """
+        Parse all of the files in a single dir corresponding to one slack channel
+
+        Each file corresponds to a single day for that channel
+        """
+        # infer the dest Discord channel if needed
+        if not self.dest_channel:
+            self.dest_channel = basename(channel_dir)
+            logger.info(f"Inferring dest Discord channel: {self.dest_channel}")
+
+        # these are the basename's only (not including the dir)
+        # this list is not sorted
+        filenames = [filename
+                     for filename in listdir(path=channel_dir)
+                     if SlackParser.is_slack_export_filename(filename)]
+
+        # sort the list so that we parse all of the files for a single channel in date order
+        for filename in sorted(filenames):
+            self.parse_file(join(channel_dir, filename))
+
+    def parse_file(self, filename):
+        """
+        Parse a single JSON file that contains exported messages from a slack channel
+
+        In practice, one file corresponds to a single calendar day of activity
 
         Compile a dict where:
         - the keys are the timestamps of the slack messages
@@ -55,6 +107,11 @@ class SlackParser():
 
         The dict is assembled in self.parsed_messages (not returned)
         """
+        logger.info(f"Parsing JSON Slack export file: {filename}")
+
+        if not SlackParser.is_slack_export_filename(filename):
+            logger.warn(f"Filename is not named as expected, will try to parse anyway: {filename}")
+
         with open(filename) as f:
             for message in json.load(f):
                 if 'user_profile' in message and 'ts' in message and 'text' in message:


### PR DESCRIPTION
via:
    `--src_dir SRC_DIR [--dest_channel DEST_CHANNEL]`

this implicitly assumes that files in the dir are of the form:
    `YYYY-MM-DD.json`
this allows us to alphabetically sort, and end up parsing the files in date order.

if files are encountered that are not named with that convention, they are skipped.

this is **not** entirely the same for the single file form of:
    `--src_file SRC_FILE --dest_channel DEST_CHANNEL`

in that case, since we are simply supplying a single file, we assume that it is find and valid. if it does not meet the expected format, just log a warning.