### PR TITLE
support multiple ways of setting discord token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+.discord_token

--- a/README.md
+++ b/README.md
@@ -1,9 +1,23 @@
-# XXX OUT OF DATE XXX
+# slack2discord
 
 This repo has hard forked (from Slackord) and is in the process of a
 significant refactoring. The new repo is slack2discord
 
 This README will be updated when that effort is complete.
+
+For now, significant help is available via:
+    ```
+    ./slack2discord.py --help
+    ```
+
+## Prereqs
+
+Install the following into a Python virtualenv:
+    ```
+    pip install discord.py decorator
+    ```
+
+# XXX OUT OF DATE XXX
 
 # Please note: Slackord 2 is out! 
 You can get it here: https://github.com/thomasloupe/Slackord2


### PR DESCRIPTION
we check, in order:

--token cmd line option
DISCORD_TOKEN env var
.discord_token file in dir of script

ultimately it is required to be set in one of these ways

(but from the perspective of argparse, it's optional)
