### PR TITLE
Implement importing multiple channels in a Slack expor

### DIFF
--- a/slack2discord.py
+++ b/slack2discord.py
@@ -25,21 +25,19 @@ if __name__ == '__main__':
 
     config = get_config(argv)
 
-    # XXX this is a WIP
-    if config.src_dirtree:
-        raise NotImplementedError("--src_dirtree (multiple channels) not yet implemented")
-
     # parse either a single file (one day of one Slack channel),
     # or all of the files in a dir (all days for one Slack channel)
     parser = SlackParser(
         src_file=config.src_file,
         src_dir=config.src_dir,
         dest_channel=config.dest_channel,
+        src_dirtree=config.src_dirtree,
+        channel_file=config.channel_file,
         verbose=config.verbose)
     parser.parse()
 
-    # post the parsed messages to a Discord channel
-    client = DiscordClient(config.token, parser.dest_channel, parser.parsed_messages,
+    # post the parsed Slack messages to Discord channel(s)
+    client = DiscordClient(config.token, parser.parsed_messages,
                            verbose=config.verbose, dry_run=config.dry_run)
     # if Ctrl-C is pressed, we do *not* get a KeyboardInterrupt
     # b/c it is caught by the run() loop in the discord client


### PR DESCRIPTION
This potentially could be all of the channels

via:
    `--src_dirtree SRC_DIRTREE [--channel_file CHANNEL_FILE]`

One dir per channel, and within each channel dir, one file per day. The src dir tree is the top level of the unzip'd Slack export. If the channel file is not given, all channels in the Slack export (all subdirs) are imported to Discord, and the channel names are the same as in Slack.

A channel file can be used to limit the channels imported, and/or to change the names of channels. Each line in the file corresponds to a single channel to import. If only one name is specified, this is the name of the channel in both Slack and Discord. If two whitespace-separated names are included, those correspond to the src Slack channel name and the dest Discord channel name respectively.

Channel names in the file should not include the leading pound sign (#), although the script will strip it off if present.

The SlackParser now has an additional dict, channel_map, that is populated via set_channel_map(), and maps the slack channel names to corresponding discord channel names. If the channel names are the same in Slack and Discord, a value can be the same as a key. The dict will have multiple items only in the src_dirtree case. In both the src_dir and src_file cases, there is only one item. In the src_file case, the key is None, and it's only the value that matters.

The existing parsed_messages in SlackParser now has an additional level of hierarchy. The keys are now Discord channel names, and the values are dicts, define as before in the case of the single parsed_messages dict. See parse() for details.

The DiscordClient has an additional level of nested loop, to iterate over all of the channels. post_messages_to_channel() posts to just one channel, and post_messages() calls that repeatedly. In theory these could be interleaved via asyncio, but keep it linear to make it far easier to reason about, esp. in the event of failures.

Do all of the setup and checking before any of the posting. set_channels() populates a new dict channels, that maps discord channel names to channel objects. We verify the all of the Discord channels exist beforehand. If not, then fail. In the future, may add an option to create channels that do not exist.