### PR TITLE
Add `--server SERVER` and `--create` command line options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .discord_token
+.pyv

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@
       member of multiple servers.
 * Add the option to create missing Discord destination channels
     * Via optional `--create` command line argument
+        * Creating channels requires the "Manage Channels" permission
     * The default is to still fail if a channel does not exist
 
 ### 2.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,16 @@
 
 ## Current releases, on [this fork](https://github.com/richfromm/slack2discord)
 
+### 2.1
+
+* Add optional `--server SERVER` command line argument
+    * This is the name of the Discord server (aka guild). This is only
+      needed in the (presumably) uncommon case in which your bot is a
+      member of multiple servers.
+* Add the option to create missing Discord destination channels
+    * Via optional `--create` command line argument
+    * The default is to still fail if a channel does not exist
+
 ### 2.0
 
 Major refactoring, with additional functionality

--- a/README.md
+++ b/README.md
@@ -225,9 +225,6 @@ time.
 
 Some items I am considering:
 
-* Optionally automatically create destination channels in Discord if
-  they do not already exist.
-
 * Minimally transform non-standard Slack Markdown as needed to conform
   to Discord Markdown.
 

--- a/README.md
+++ b/README.md
@@ -143,18 +143,22 @@ For complete instructions, see <https://discordpy.readthedocs.io/en/stable/disco
 
    Applications -> Settings -> OAuth2 -> URL Generator -> Scopes: check "**bot**"
 
+   Bot permissions -> General permissions:
+
+   check: "**Manage Channels**"
+
    Bot permissions -> Text permissions:
 
-   check: "**Send Messages**", "**Create Public Threads**", "**Create Private Threads**"
+   additionally check: "**Send Messages**", "**Create Public Threads**", "**Send Messages in Threads**"
 
    This will create a URL that you can use to add the bot to your server.
 
-    * Go to Generated URL
-    * Copy the URL
+    * Go to **Generated URL**
+    * **Copy** the URL
     * Paste into your browser
     * Login if requested
     * Select your Discord server, and authorize the external application to
-       access your Discord account.
+       access your Discord account, confirming the above permissions.
     * -> **Continue** -> **Authorize**
     * Do the Captcha if requested
     * Close the browser tab
@@ -230,7 +234,7 @@ Some items I am considering:
 * Deal with external links in Discord, showing the same preview title,
   heading, text, and image that Slack does.
 
-* Better error reporting, so that if an entire export is not
+* Better error reporting, so that if an entire import is not
   successful, it is easier to resume in a way as to avoid duplicates.
 
 * Add mypy type hints.

--- a/README.md
+++ b/README.md
@@ -173,7 +173,8 @@ following manners. This is the order that is searched:
 
 Briefly, the script is executed via:
 
-    ./slack2discord.py [--token TOKEN] [-v | --verbose] [-n | --dry-run] <src-and-dest-related-options>
+    ./slack2discord.py [--token TOKEN] [--server SERVER] \
+        [-v | --verbose] [-n | --dry-run] <src-and-dest-related-options>
 
 The src and dest related options can be specified in one of three different
 ways:

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ following manners. This is the order that is searched:
 
 Briefly, the script is executed via:
 
-    ./slack2discord.py [--token TOKEN] [--server SERVER] \
+    ./slack2discord.py [--token TOKEN] [--server SERVER] [--create] \
         [-v | --verbose] [-n | --dry-run] <src-and-dest-related-options>
 
 The src and dest related options can be specified in one of three different

--- a/slack2discord.py
+++ b/slack2discord.py
@@ -38,7 +38,8 @@ if __name__ == '__main__':
 
     # post the parsed Slack messages to Discord channel(s)
     client = DiscordClient(
-        token=config.token, parsed_messages=parser.parsed_messages, server_name=config.server,
+        token=config.token, parsed_messages=parser.parsed_messages,
+        server_name=config.server, create_channels=config.create,
         verbose=config.verbose, dry_run=config.dry_run)
     # if Ctrl-C is pressed, we do *not* get a KeyboardInterrupt
     # b/c it is caught by the run() loop in the discord client

--- a/slack2discord.py
+++ b/slack2discord.py
@@ -37,8 +37,9 @@ if __name__ == '__main__':
     parser.parse()
 
     # post the parsed Slack messages to Discord channel(s)
-    client = DiscordClient(config.token, parser.parsed_messages,
-                           verbose=config.verbose, dry_run=config.dry_run)
+    client = DiscordClient(
+        token=config.token, parsed_messages=parser.parsed_messages, server_name=config.server,
+        verbose=config.verbose, dry_run=config.dry_run)
     # if Ctrl-C is pressed, we do *not* get a KeyboardInterrupt
     # b/c it is caught by the run() loop in the discord client
     client.run()

--- a/slack2discord/client.py
+++ b/slack2discord/client.py
@@ -153,6 +153,8 @@ class DiscordClient(discord.Client):
                 logger.warn("Unable to find category for text channels, new channel will"
                             " not be in a category")
 
+            # This requires the "Manage Channels" permission
+            # https://discordpy.readthedocs.io/en/latest/api.html#discord.Guild.create_text_channel
             channel = await guild.create_text_channel(channel_name, category=text_channels_category)
             assert(channel.name == channel_name, f"New channel has unexpected name: {channel.name}")
 
@@ -209,8 +211,8 @@ class DiscordClient(discord.Client):
         If the channel exists, populate an item mapping the channel name to the channel object in
         the self.channels dict.
 
-        If any channel does not exist, either create it, or raise an exception, depending on
-        whether the option was selected to create missing channels.
+        If any channel does not exist, either create it, or raise a RuntimeError, depending on
+        whether the config option was selected to create missing channels.
         """
         channel_names_from_export = self.parsed_messages.keys()
         logger.info("Checking that all Discord channels to which we want to post exist:"

--- a/slack2discord/config.py
+++ b/slack2discord/config.py
@@ -16,7 +16,8 @@ DESCRIPTION = dedent(
 
 USAGE = dedent(
     f"""
-    {argv[0]} [--token TOKEN] [-v | --verbose] [-n | --dry-run] <src-and-dest-related-options>
+    {argv[0]} [--token TOKEN] [--server SERVER] \\
+        [-v | --verbose] [-n | --dry-run] <src-and-dest-related-options>
 
     src and dest related options must follow one of the following mutually exclusive formats:
 
@@ -151,6 +152,12 @@ def get_config(argv):
                         " If not set via command line option, will search in order in"
                         " DISCORD_TOKEN env var, then .discord_token file in same dir as script."
                         " Must be set in one of these locations.")
+
+    parser.add_argument('--server',
+                        required=False,
+                        help="Name of Discord server. Not needed in the common case where your bot"
+                        " is only a member of a single server. Only needed if Discord server"
+                        " disambiguation is required.")
 
     parser.add_argument('--src-file',
                         required=False,

--- a/slack2discord/config.py
+++ b/slack2discord/config.py
@@ -16,7 +16,7 @@ DESCRIPTION = dedent(
 
 USAGE = dedent(
     f"""
-    {argv[0]} [--token TOKEN] [--server SERVER] \\
+    {argv[0]} [--token TOKEN] [--server SERVER] [--create] \\
         [-v | --verbose] [-n | --dry-run] <src-and-dest-related-options>
 
     src and dest related options must follow one of the following mutually exclusive formats:
@@ -109,6 +109,9 @@ def check_config(config):
     The Discord token can also be set in various was (see get_token()), but ultimately it must be
     set.
     """
+    if config.verbose:
+        logger.info(f"config = {config}")
+
     # These are all mutually exclusive
     one_file = config.src_file is not None
     one_channel = config.src_dir is not None
@@ -158,6 +161,12 @@ def get_config(argv):
                         help="Name of Discord server. Not needed in the common case where your bot"
                         " is only a member of a single server. Only needed if Discord server"
                         " disambiguation is required.")
+
+    parser.add_argument('--create',
+                        required=False,
+                        action='store_true',
+                        help="Optionally create any destination Discord text channel if it does not"
+                        " exist. Default behavior is to fail if destination channel is missing.")
 
     parser.add_argument('--src-file',
                         required=False,

--- a/slack2discord/parser.py
+++ b/slack2discord/parser.py
@@ -4,7 +4,6 @@ import logging
 from os import listdir
 from os.path import basename, join, isdir
 from re import match
-import time
 
 
 logger = logging.getLogger(__name__)

--- a/slack2discord/parser.py
+++ b/slack2discord/parser.py
@@ -132,8 +132,8 @@ class SlackParser():
                             if slack_channel not in all_slack_channels:
                                 raise ValueError(
                                     f"Slack channel {slack_channel} from channel file"
-                                    " {self.channel_file} is not in the slack export at"
-                                    " {self.src_dirtree}")
+                                    f" {self.channel_file} is not in the slack export at"
+                                    f" {self.src_dirtree}")
                             if len(fields) == 1:
                                 # slack channel only, discord channel is same
                                 self.channel_map[slack_channel] = slack_channel


### PR DESCRIPTION
* Add optional `--server SERVER` command line argument
    * This is the name of the Discord server (aka guild). This is only
      needed in the (presumably) uncommon case in which your bot is a
      member of multiple servers.
* Add the option to create missing Discord destination channels
    * Via optional `--create` command line argument
    * The default is to still fail if a channel does not exist
