### PR TITLE
Better processing of name within Slack messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,14 @@
 
 ## Current releases, on [this fork](https://github.com/richfromm/slack2discord)
 
+### 2.2
+
+* Better processing of name within Slack messages
+    * Use a searchlist covering display name, real name, and user
+    * This handles the bot case with no user profile
+    * This fixes
+      [issue#13](https://github.com/richfromm/slack2discord/issues/13)
+
 ### 2.1
 
 * Add optional `--server SERVER` command line argument

--- a/README.md
+++ b/README.md
@@ -231,10 +231,12 @@ Some items I am considering:
 * Deal with external links in Discord, showing the same preview title,
   heading, text, and image that Slack does.
 
+* Support attached files
+
 * Better error reporting, so that if an entire import is not
   successful, it is easier to resume in a way as to avoid duplicates.
 
-* Add mypy type hints.
+* Add mypy type hints
 
 * Add unit tests
 

--- a/slack2discord/client.py
+++ b/slack2discord/client.py
@@ -119,13 +119,13 @@ class DiscordClient(discord.Client):
                       if category.name == category_name]
         if not categories:
             # Uncategorized channels appear separately in the Discord GUI
-            logger.warn("Unable to find category with name {category_name}")
+            logger.warning(f"Unable to find category with name {category_name}")
             category = None
         else:
             if len(categories) > 1:
                 # I suspect this is not actually possible in practice
-                logger.warn("Found multiple categories with name {category_name}, will arbitrarily"
-                            " pick the first")
+                logger.warning(f"Found multiple categories with name {category_name}, will"
+                               " arbitrarily pick the first")
             category = categories[0]
 
         return category
@@ -150,8 +150,8 @@ class DiscordClient(discord.Client):
         else:
             text_channels_category = self.get_category(guild, 'Text Channels')
             if not text_channels_category:
-                logger.warn("Unable to find category for text channels, new channel will"
-                            " not be in a category")
+                logger.warning("Unable to find category for text channels, new channel will not be"
+                               " in a category")
 
             # This requires the "Manage Channels" permission
             # https://discordpy.readthedocs.io/en/latest/api.html#discord.Guild.create_text_channel
@@ -230,7 +230,8 @@ class DiscordClient(discord.Client):
                                              create=self.create_channels, dry_run=self.dry_run)
             self.channels[channel_name] = channel
 
-        logger.info(f"Successfully got all Discord channels to which we will be posting: {self.channels.keys()}")
+        logger.info("Successfully got all Discord channels to which we will be posting:"
+                    f" {self.channels.keys()}")
 
     async def post_messages(self):
         """
@@ -342,7 +343,7 @@ class DiscordClient(discord.Client):
                     retry_idx = min(retry_count - 1, len(retry_backoff) - 1)
                     retry_sec = retry_backoff[retry_idx]
 
-                logger.warn(f"{exc_msg} {desc}: {e}")
+                logger.warning(f"{exc_msg} {desc}: {e}")
                 logger.info(f"Will retry #{retry_count} after {retry_sec} seconds, press Ctrl-C to abort")
                 await asyncio.sleep(retry_sec)
 

--- a/slack2discord/parser.py
+++ b/slack2discord/parser.py
@@ -235,8 +235,8 @@ class SlackParser():
                          for filename in listdir(path=channel_dir)
                          if SlackParser.is_slack_export_filename(filename)]
             if not filenames:
-                logger.warn("Unable to find any slack export JSON files for slack channel"
-                            f" {slack_channel} in dir {channel_dir}")
+                logger.warning("Unable to find any slack export JSON files for slack channel"
+                               f" {slack_channel} in dir {channel_dir}")
                 # XXX or should this be fatal and raise an Exception ?
                 return
 
@@ -273,14 +273,15 @@ class SlackParser():
         logger.info(f"Parsing Slack export JSON file: {filename}")
 
         if not SlackParser.is_slack_export_filename(filename):
-            logger.warn(f"Filename is not named as expected, will try to parse anyway: {filename}")
+            logger.warning("Filename is not named as expected, will try to parse anyway:"
+                           f" {filename}")
 
         with open(filename) as _file:
             for message in json.load(_file):
                 if message.get('type') == 'message':
                     if 'ts' not in message:
                         # According to the docs, 'ts' should always be present
-                        logger.warn("Message is missing timestamp, skipping.")
+                        logger.warning("Message is missing timestamp, skipping.")
                         continue
 
                     timestamp = float(message['ts'])
@@ -303,8 +304,9 @@ class SlackParser():
                             # can't find the root of the thread to which this message belongs
                             # ideally this shouldn't happen
                             # but it could if you have a long enough message history not captured in the exported file
-                            logger.warning(f"Can't find thread with timestamp {thread_timestamp} for message with timestamp {timestamp},"
-                                           " creating synthetic thread")
+                            logger.warning(f"Can't find thread with timestamp {thread_timestamp} for"
+                                           f" message with timestamp {timestamp}, creating"
+                                           " synthetic thread")
                             fake_message_text = SlackParser.format_message(
                                 thread_timestamp, None, '_Unable to find start of exported thread_')
                             channel_msgs_dict[thread_timestamp] = (fake_message_text, dict())


### PR DESCRIPTION
* Use a searchlist covering display name, real name, and user
* This handles the bot case with no user profile
* This fixes [issue#13](https://github.com/richfromm/slack2discord/issues/13)
