### PR TITLE
Numerous formatting improvements, and fix bug with command line args of dir paths

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,22 @@
 
 ## Current releases, on [this fork](https://github.com/richfromm/slack2discord)
 
+### 2.4
+
+* Numerous formatting improvements
+    * Fix non-standard Slack markdown syntax for **bold** and
+      ~~strikethrough~~
+    * Unescape HTML entities for Slack control characters (`&`, `<`,
+      and `>`)
+* Canonicalize directory paths specified as command line arguments
+    * This fixes a bug where a certain forms of the `--src-dir` option
+      value caused the inferred destination channel (if not explicitly
+      specified with the optional `--dest-channel`) to not be properly
+      set to the last directory in the path
+    * A trailing slash (on Unix) caused the dest channel to be `None`
+    * Ending with a relative path (e.g. `.` or `..`) would set that to
+      the dest channel name
+
 ### 2.3
 
 * Handle links within Slack messages

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@
     * Unescape HTML entities for Slack control characters (`&`, `<`,
       and `>`)
 * Canonicalize directory paths specified as command line arguments
-    * This fixes a bug where a certain forms of the `--src-dir` option
+    * This fixes a bug where certain forms of the `--src-dir` option
       value caused the inferred destination channel (if not explicitly
       specified with the optional `--dest-channel`) to not be properly
       set to the last directory in the path

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,8 +12,8 @@
 * Canonicalize directory paths specified as command line arguments
     * This fixes a bug where certain forms of the `--src-dir` option
       value caused the inferred destination channel (if not explicitly
-      specified with the optional `--dest-channel`) to not be properly
-      set to the last directory in the path
+      specified with the optional `--dest-channel` option) to not be
+      properly set to the last directory in the path
     * A trailing slash (on Unix) caused the dest channel to be `None`
     * Ending with a relative path (e.g. `.` or `..`) would set that to
       the dest channel name

--- a/README.md
+++ b/README.md
@@ -225,15 +225,14 @@ time.
 
 * [Slack: How to read Slack data exports](https://slack.com/help/articles/220556107-How-to-read-Slack-data-exports)
 * [Slack: Reference: Message payloads](https://api.slack.com/reference/messaging/payload)
-* [Slack: Formatting text for app surfaces](https://api.slack.com/reference/surfaces/formatting#basics)
+* [Slack: Formatting text for app surfaces](https://api.slack.com/reference/surfaces/formatting)
 * [discord.py: API Reference](https://discordpy.readthedocs.io/en/latest/api.html)
+* [Markdown Guide: Slack](https://www.markdownguide.org/tools/slack/)
+* [Markdown Guide: Discord](https://www.markdownguide.org/tools/discord/)
 
 ## Future work
 
 Some items I am considering:
-
-* Minimally transform non-standard Slack Markdown as needed to conform
-  to Discord Markdown.
 
 * Support attached files
 

--- a/slack2discord/parser.py
+++ b/slack2discord/parser.py
@@ -2,7 +2,7 @@ from datetime import datetime
 import json
 import logging
 from os import listdir
-from os.path import basename, join, isdir, normpath
+from os.path import basename, join, isdir, realpath
 from re import match, sub
 
 from .message import ParsedMessage
@@ -22,10 +22,11 @@ class SlackParser():
                  verbose=False):
         # These are from the config, some will be None
         self.src_file = src_file
-        # need to normalize to properly infer channel name if dir ends in path separator
-        self.src_dir = normpath(src_dir) if src_dir else None
+        # canonicalize path to properly infer channel name in non-obvious situations, e.g. dir ends
+        # in path separator, minimal relative paths (e.g. '.' or '..')
+        self.src_dir = realpath(src_dir) if src_dir else None
         self.dest_channel = dest_channel
-        self.src_dirtree = normpath(src_dirtree) if src_dirtree else None
+        self.src_dirtree = realpath(src_dirtree) if src_dirtree else None
         self.channel_file = channel_file
         self.verbose = verbose
 

--- a/slack2discord/parser.py
+++ b/slack2discord/parser.py
@@ -2,7 +2,7 @@ from datetime import datetime
 import json
 import logging
 from os import listdir
-from os.path import basename, join, isdir
+from os.path import basename, join, isdir, normpath
 from re import match, sub
 
 from .message import ParsedMessage
@@ -22,9 +22,10 @@ class SlackParser():
                  verbose=False):
         # These are from the config, some will be None
         self.src_file = src_file
-        self.src_dir = src_dir
+        # need to normalize to properly infer channel name if dir ends in path separator
+        self.src_dir = normpath(src_dir) if src_dir else None
         self.dest_channel = dest_channel
-        self.src_dirtree = src_dirtree
+        self.src_dirtree = normpath(src_dirtree) if src_dirtree else None
         self.channel_file = channel_file
         self.verbose = verbose
 

--- a/slack2discord/parser.py
+++ b/slack2discord/parser.py
@@ -87,6 +87,26 @@ class SlackParser():
         return sub('\\\/', '/', url)
 
     @staticmethod
+    def unescape_text(text):
+        """
+        The slack export converts slack control characters to HTML entities. Undo this.
+
+        Return the unescaped string.
+
+        * ampersand (&) is (&amp;)
+        * less than sign (<) is (&lt;)
+        * greater than sign (>) is (&gt;)
+
+        For more details, see:
+        https://api.slack.com/reference/surfaces/formatting#escaping
+        """
+        unescaped_amp = sub('&amp;', '&', text)
+        unescaped_amp_lt = sub('&lt;', '<', unescaped_amp)
+        unescaped_amp_lt_gt = sub('&gt;', '>', unescaped_amp_lt)
+
+        return unescaped_amp_lt_gt
+
+    @staticmethod
     def fix_markdown(text):
         """
         Fix some non-standard Slack Markdown syntax
@@ -362,7 +382,10 @@ class SlackParser():
         # supported), the key should be present, with an empty string value.
         # Regardless, provide an empty string as a default value just in case it's not
         # present.
-        message_text = SlackParser.fix_markdown(SlackParser.unescape_url(message.get('text', "")))
+        message_text = SlackParser.fix_markdown(
+            SlackParser.unescape_text(
+            SlackParser.unescape_url(
+            message.get('text', ""))))
         full_message_text = SlackParser.format_message(timestamp, name, message_text)
         parsed_message = ParsedMessage(full_message_text)
         if 'attachments' in message:

--- a/slack2discord/parser.py
+++ b/slack2discord/parser.py
@@ -116,12 +116,12 @@ class SlackParser():
         This works across multiple lines.
 
         This addresses the following non-standard Slack Markdown:
-        * Slack uses *one* asterisk for bold, standard (and Discord) is **two**
+        * Slack uses *one* asterisk for bold; standard (and Discord) is **two**
 
           (One asterisk is standard Markdown for italic. Thankfully, the alternative of _one_
-          underscore works in both Slack and Discord, so there is nothing to do here.)
+          underscore works in both Slack and Discord, so there is nothing to do for this.)
 
-        * Slack uses ~one~ tilde for strikethrough, standard (and Discord) is ~~two~~
+        * Slack uses ~one~ tilde for strikethrough; standard (and Discord) is ~~two~~
 
         For more details, see:
         * https://www.markdownguide.org/tools/slack/

--- a/slack2discord/parser.py
+++ b/slack2discord/parser.py
@@ -127,14 +127,14 @@ class SlackParser():
         * https://www.markdownguide.org/tools/slack/
         * https://www.markdownguide.org/tools/discord/
         """
-        # The asterisk for bold needs to be escape in the regex, b/c otherwise it means "0 or more"
-        # It does *not* need to be escaped in the substitution string
+        # The asterisk for bold needs to be escaped in the regex, b/c otherwise it means "0 or
+        # more". It does *not* need to be escaped in the substitution string.
         SLACK_BOLD_RE = "(\*)(\S+|\S.*\S)(\*)"
         DISCORD_BOLD_SUB = r"\1*\2*\3"
         text_bold_fixed = sub(
             SLACK_BOLD_RE, DISCORD_BOLD_SUB, text)
 
-        # A tilde for strikethrough is not a regex special char, so needs no escaping
+        # A tilde for strikethrough is not a regex special char, so needs no escaping.
         SLACK_STRIKETHROUGH_RE = "(~)(\S+|\S.*\S)(~)"
         DISCORD_STRIKETHROUGH_SUB = r"\1~\2~\3"
         text_bold_and_strikethrough_fixed = sub(
@@ -385,8 +385,8 @@ class SlackParser():
         # present.
         message_text = SlackParser.fix_markdown(
             SlackParser.unescape_text(
-            SlackParser.unescape_url(
-            message.get('text', ""))))
+                SlackParser.unescape_url(
+                    message.get('text', ""))))
         full_message_text = SlackParser.format_message(timestamp, name, message_text)
         parsed_message = ParsedMessage(full_message_text)
         if 'attachments' in message:


### PR DESCRIPTION
* Numerous formatting improvements
    * Fix non-standard Slack markdown syntax for **bold** and
      ~~strikethrough~~
    * Unescape HTML entities for Slack control characters (`&`, `<`,
      and `>`)
* Canonicalize directory paths specified as command line arguments
    * This fixes a bug where certain forms of the `--src-dir` option
      value caused the inferred destination channel (if not explicitly
      specified with the optional `--dest-channel`) to not be properly
      set to the last directory in the path
    * A trailing slash (on Unix) caused the dest channel to be `None`
    * Ending with a relative path (e.g. `.` or `..`) would set that to
      the dest channel name
