### PR TITLE
Add support for files attached to messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__
 .discord_token
 .pyv
+downloads
+*.~*~

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,15 @@
 
 ## Current releases, on [this fork](https://github.com/richfromm/slack2discord)
 
+### 2.5 (in progress)
+
+* Add support for files attached to messages
+    * Files are downloaded from Slack then uploaded to Discord and
+      attached to messages
+    * Add optional `--downloads-dir DOWNLOADS_DIR` command line argument
+        * Defaults to a newly created dir of the form
+          `./downloads/<timestamp>` relative to the locatoin of the script.
+
 ### 2.4
 
 * Numerous formatting improvements

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
       attached to messages
     * Add optional `--downloads-dir DOWNLOADS_DIR` command line argument
         * Defaults to a newly created dir of the form
-          `./downloads/<timestamp>` relative to the locatoin of the script.
+          `./downloads/<timestamp>` relative to the location of the script.
 
 ### 2.4
 

--- a/README.md
+++ b/README.md
@@ -29,16 +29,23 @@ originates.
 
 ### virtualenv
 
-Install `discord.py` ([pypi](https://pypi.org/project/discord.py/),
-[homepage](https://github.com/Rapptz/discord.py),
-[docs](https://discordpy.readthedocs.io/en/latest/)) (_yes, there
-really is a `.py` included in the package name_) and `decorator`
-([pypi](https://pypi.org/project/decorator/),
-[homepage](https://github.com/micheles/decorator),
-[docs](https://github.com/micheles/decorator/blob/master/docs/documentation.md))
-packages into a Python virtualenv:
+Install the following packages into a Python virtualenv:
 
-    pip install discord.py decorator
+* `discord.py` ([docs](https://discordpy.readthedocs.io/en/latest/),
+[pypi](https://pypi.org/project/discord.py/),
+[source](https://github.com/Rapptz/discord.py)) (_yes, there really is
+a `.py` suffix included in the package name_)
+* `decorator`
+([docs](https://github.com/micheles/decorator/blob/master/docs/documentation.md),
+[pypi](https://pypi.org/project/decorator/),
+[source](https://github.com/micheles/decorator))
+* `requests` ([docs](https://requests.readthedocs.io/en/latest/),
+[pypi](https://pypi.org/project/requests/),
+[source](https://github.com/psf/requests))
+
+via:
+
+    pip install discord.py decorator requests
 
 For help creating virtual environments, see the
 [venv](https://docs.python.org/3/library/venv.html) docs. If you use Python a
@@ -177,7 +184,7 @@ following manners. This is the order that is searched:
 
 Briefly, the script is executed via:
 
-    ./slack2discord.py [--token TOKEN] [--server SERVER] [--create] \
+    ./slack2discord.py [--token TOKEN] [--server SERVER] [--create] [--downloads-dir DOWNLOADS_DIR] \
         [-v | --verbose] [-n | --dry-run] <src-and-dest-related-options>
 
 The src and dest related options can be specified in one of three different
@@ -234,14 +241,18 @@ time.
 
 Some items I am considering:
 
-* Support attached files
-
 * Better error reporting, so that if an entire import is not
   successful, it is easier to resume in a way as to avoid duplicates.
 
 * Add mypy type hints
 
 * Add unit tests
+
+* Ways to optimize file downloads:
+    * Download multiple files asynchronously via using
+      [aiohttp](https://docs.aiohttp.org/en/stable/)
+    * Stream file downloads in chunks via
+      [`Response.iter_content`](https://requests.readthedocs.io/en/latest/api/#requests.Response.iter_content)
 
 Feel free to open issues in GitHub if there are any other features you
 would like to see.

--- a/slack2discord.pyv
+++ b/slack2discord.pyv
@@ -1,2 +1,3 @@
 discord.py
 decorator
+requests

--- a/slack2discord/client.py
+++ b/slack2discord/client.py
@@ -156,7 +156,7 @@ class DiscordClient(discord.Client):
             # This requires the "Manage Channels" permission
             # https://discordpy.readthedocs.io/en/latest/api.html#discord.Guild.create_text_channel
             channel = await guild.create_text_channel(channel_name, category=text_channels_category)
-            assert(channel.name == channel_name, f"New channel has unexpected name: {channel.name}")
+            assert channel.name == channel_name, f"New channel has unexpected name: {channel.name}"
 
         return channel
 
@@ -271,6 +271,18 @@ class DiscordClient(discord.Client):
             await self.close()
 
     async def post_messages_to_channel(self, channel, channel_msgs_dict):
+        """
+        This posts all of the messages of the previously parsed JSON files form a Slack export
+        to a single channel.
+
+        For threaded messages, a new thread is created at the root message, and the remaining
+        messages for that thread are posted to that thread.
+
+        Links are preserved when sending the messages to Discord.
+
+        Files are added after sending the messages to Discord.
+
+        """
         logger.info(f"Begin posting messages to Discord channel {channel}")
 
         for timestamp in sorted(channel_msgs_dict.keys()):
@@ -278,14 +290,22 @@ class DiscordClient(discord.Client):
             sent_message = await self.send_msg_to_channel(
                 channel, message.get_discord_send_kwargs())
             logger.info(f"Message posted: {timestamp}")
+            if message.files:
+                await self.add_files_to_message(
+                    sent_message, message.get_discord_add_files_args())
+                logger.info(f"{len(message.files)} files added to message")
 
             if thread:
                 created_thread = await self.create_thread(sent_message, f"thread{timestamp}")
                 for timestamp_in_thread in sorted(thread.keys()):
                     thread_message = thread[timestamp_in_thread]
-                    await self.send_msg_to_thread(
+                    sent_thread_message = await self.send_msg_to_thread(
                         created_thread, thread_message.get_discord_send_kwargs())
                     logger.info(f"Message in thread posted: {timestamp_in_thread}")
+                    if thread_message.files:
+                        await self.add_files_to_message(
+                            sent_thread_message, thread_message.get_discord_add_files_args())
+                        logger.info(f"{len(message.files)} files added to message in thread")
 
         # XXX maybe set a boolean to indicate success to the caller,
         #     if actual return values are hard?
@@ -390,3 +410,17 @@ class DiscordClient(discord.Client):
             return
 
         return await thread.send(**send_kwargs)
+
+    @discord_retry(desc="adding files to message")
+    async def add_files_to_message(self, message, add_files_args):
+        """
+        Add files to a message by uploading as attachments
+
+        In the event of failure, will retry indefinitely until successful.
+        See discord_retry() docstring for more details.
+        """
+        if self.dry_run:
+            logger.info("DRY_RUN: message.add_files(*add_files_args)")
+            return
+
+        return await message.add_files(*add_files_args)

--- a/slack2discord/client.py
+++ b/slack2discord/client.py
@@ -272,7 +272,7 @@ class DiscordClient(discord.Client):
 
     async def post_messages_to_channel(self, channel, channel_msgs_dict):
         """
-        This posts all of the messages of the previously parsed JSON files form a Slack export
+        This posts all of the messages of the previously parsed JSON files from a Slack export
         to a single channel.
 
         For threaded messages, a new thread is created at the root message, and the remaining
@@ -281,7 +281,6 @@ class DiscordClient(discord.Client):
         Links are preserved when sending the messages to Discord.
 
         Files are added after sending the messages to Discord.
-
         """
         logger.info(f"Begin posting messages to Discord channel {channel}")
 

--- a/slack2discord/config.py
+++ b/slack2discord/config.py
@@ -210,7 +210,7 @@ def get_config(argv):
     parser.add_argument('-v', '--verbose',
                         required=False,
                         action='store_true',
-                        help="Enable verbose outout")
+                        help="Enable verbose output")
 
     parser.add_argument('-n', '--dry-run',
                         required=False,

--- a/slack2discord/config.py
+++ b/slack2discord/config.py
@@ -16,7 +16,7 @@ DESCRIPTION = dedent(
 
 USAGE = dedent(
     f"""
-    {argv[0]} [--token TOKEN] [--server SERVER] [--create] \\
+    {argv[0]} [--token TOKEN] [--server SERVER] [--create] [--downloads-dir DOWNLOADS_DIR] \\
         [-v | --verbose] [-n | --dry-run] <src-and-dest-related-options>
 
     src and dest related options must follow one of the following mutually exclusive formats:
@@ -197,13 +197,28 @@ def get_config(argv):
                         help="File containing list of Slack channels to port to Discord, with"
                         " optional mapping to Discord channels if named differently.")
 
+    parser.add_argument('--downloads-dir',
+                        required=False,
+                        default=None,
+                        help="Directory in which to download any files attached to Slack messages,"
+                        " before uploading them to Discord. If not present, will default to a"
+                        " newly created dir of the form './downloads/<timestamp>', relative to the"
+                        " location of this script. Unless resuming from a previously failed script"
+                        " execution, it is highly recommended that each execution of the script"
+                        " use a unique directory.")
+
     parser.add_argument('-v', '--verbose',
                         required=False,
-                        action='store_true')
+                        action='store_true',
+                        help="Enable verbose outout")
 
     parser.add_argument('-n', '--dry-run',
                         required=False,
-                        action='store_true')
+                        action='store_true',
+                        help="Don't change any state in Discord. Note that dry run is **only**"
+                        " relative to Discord. Messages are still parsed from slack, and if"
+                        " necessary the downloads dir will be created locally, and files will be"
+                        " downloaded from Slack into that dir.")
 
     config = parser.parse_args()
     get_token(config)

--- a/slack2discord/downloader.py
+++ b/slack2discord/downloader.py
@@ -36,9 +36,9 @@ class SlackDownloader():
                 error_msg = f"Downloads dir already exists but is **NOT** a dir: {downloads_dir}"
                 logger.error(error_msg)
                 raise RuntimeError(error_msg)
-        # hold off on creating if it doesn't exist, only create if need
-        # (if prasing includes any files)
 
+        # hold off on creating if it doesn't exist, only create if needed
+        # (if parsing includes any files)
         self.downloads_dir = downloads_dir
 
         self.files: list[MessageFile] = []
@@ -68,7 +68,7 @@ class SlackDownloader():
         # keys are channel names, values are per-channel dicts
         for channel_msgs_dict in self.parsed_messages.values():
             # keys are timestamps, values are tuples
-            # tuples containt ParsedMessage object and an optional dict
+            # tuples containt ParsedMessage object and an optional dict for a thread
             for parsed_message, thread in channel_msgs_dict.values():
                 self._add_files(parsed_message)
                 if thread:
@@ -97,6 +97,7 @@ class SlackDownloader():
 
         This is a blocking call.
         """
+        # We're basically emulating this wget command
         logger.debug(f"wget -O {filename} {url}")
         if exists(filename):
             logger.warning(f"local filename already exists, will overwrite: {filename}")

--- a/slack2discord/downloader.py
+++ b/slack2discord/downloader.py
@@ -1,0 +1,135 @@
+import logging
+from os import makedirs
+from os.path import dirname, exists, isdir, join, realpath
+from time import time
+
+from requests import get
+
+from .message import ParsedMessage, MessageFile
+
+
+logger = logging.getLogger(__name__)
+
+
+class SlackDownloader():
+    """
+    Download a list of previously parsed files attached to Slack messages.
+    Once the files exist locally, they can then be uploaded to corresponding Discord messages.
+    """
+    def __init__(self,
+                 parsed_messages: dict,
+                 downloads_dir: str = None):
+        # see SlackParser.parse() for details
+        self.parsed_messages = parsed_messages
+
+        if downloads_dir is None:
+            # second level accuracy is probably sufficient
+            # multiple callers shouldn't invoke this script within the same second
+            downloads_dir = join(dirname(__file__), '..', 'downloads', str(int(time())))
+
+        downloads_dir = realpath(downloads_dir)
+        logger.info(f"Downloaded files from Slack (if any) will be placed in {downloads_dir}")
+        if exists(downloads_dir):
+            if isdir(downloads_dir):
+                logger.warn(f"Downloads dir already exists: {downloads_dir}")
+            else:
+                error_msg = f"Downloads dir already exists but is **NOT** a dir: {downloads_dir}"
+                logger.error(error_msg)
+                raise RuntimeError(error_msg)
+        # hold off on creating if it doesn't exist, only create if need
+        # (if prasing includes any files)
+
+        self.downloads_dir = downloads_dir
+
+        self.files: list[MessageFile] = []
+
+    def _add_files(self, message: ParsedMessage) -> None:
+        """
+        Add to the list of self.files as appropriate for the given parsed message
+
+        Each message can contain zero or more files
+
+        self.files is modified in place, nothing is returned
+        """
+        for file in message.files:
+            self.files.append(file)
+
+    def _populate_files(self) -> None:
+        """
+        Populate the list of self.files to download
+
+        Iterate through self.parsed_messages
+        Find all of the messages that contain files
+
+        self.files is modified in place, nothing is returned
+        """
+        # See SlackParser.parse() for more documentation on self.parsed_messages
+
+        # keys are channel names, values are per-channel dicts
+        for channel_msgs_dict in self.parsed_messages.values():
+            # keys are timestamps, values are tuples
+            # tuples containt ParsedMessage object and an optional dict
+            for parsed_message, thread in channel_msgs_dict.values():
+                self._add_files(parsed_message)
+                if thread:
+                    # if present, thread is a dict
+                    # keys are timestamps, values are ParsedMessage objects
+                    for thread_message in thread.values():
+                        self._add_files(thread_message)
+
+    def _wget(self, url, filename) -> None:
+        """
+        Fetch a file via HTTP GET from the given URL, and store it in the local filename.
+
+        Nothing is returned on success.
+        HTTP errors are raised as Exception's
+
+        This is a simple implementation. We could instead stream data in chunks using
+        Response.iter_content:
+            https://requests.readthedocs.io/en/latest/api/#requests.Response.iter_content
+        It is assumed that the files are in practice small enough that it's not worth it.
+
+        We are unconditionally downloading the file. We could potentially try to determine if we
+        already have the file (e.g. if a file exists locally of the same name, and its size in
+        bytes matches the 'Content-Length:' header), but this is not currently
+        implemented. Re-downloads will simply overwrite the previous contents, if made to the same
+        downloads dir.
+
+        This is a blocking call.
+        """
+        logger.debug(f"wget -O {filename} {url}")
+        if exists(filename):
+            logger.warning(f"local filename already exists, will overwrite: {filename}")
+
+        with get(url) as req:
+            req.raise_for_status()
+            with open(filename, 'wb') as file:
+                file.write(req.content)
+
+    def download(self) -> None:
+        """
+        Download all of the files from parsed messages to the downloads dir.
+        Create the downloads dir if needed.
+
+        The downloads are all done sequentially. This could be made faster with aiohttp:
+        https://docs.aiohttp.org/en/stable/
+        """
+        self._populate_files()
+
+        if not self.files:
+            logger.info("There are no files to download")
+            return
+
+        logger.info(
+            f"There are {len(self.files)} files to download, will place in {self.downloads_dir}")
+        if not exists(self.downloads_dir):
+            makedirs(self.downloads_dir)
+
+        for file in self.files:
+            # using file.name would be more descriptive
+            # but that risks filename collisions
+            # we could place each file in its own dir, e.g. self.downloads_dir/file.id/file.name
+            # but that would be more awkward to work with
+            file.local_filename = join(self.downloads_dir, file.id)
+            self._wget(file.url, file.local_filename)
+        logger.info(f"Successfully downloaded {len(self.files)} files to {self.downloads_dir}")

--- a/slack2discord/message.py
+++ b/slack2discord/message.py
@@ -23,7 +23,23 @@ class ParsedMessage():
     """
     def __init__(self, text):
         self.text = text
-        self.links = []
+        self.links: list[MessageLink] = []
+        self.files: list[MessageFile] = []
+
+    @staticmethod
+    def str_or_none(val):
+        """
+        Return a string of a value suitable for a string representation of the form:
+           key='value'
+        The point is that we **do** want the quotes if it's really a string,
+        but we do **not** want the quotes if the value is None.
+
+        Used with MessageLink and MessageFile
+        """
+        if val is None:
+            return f"{val}"
+
+        return f"'{val}'"
 
     def add_link(self, link_dict):
         """
@@ -55,8 +71,34 @@ class ParsedMessage():
 
         self.links.append(link)
 
+    def add_file(self, file_dict):
+        """
+        Add the info for a file to the parsed message
+
+        This is stored internally as self.files, which is a list of MessageFile
+
+        For more details, see:
+        https://discordpy.readthedocs.io/en/latest/api.html#discord.Message.add_files
+        https://discordpy.readthedocs.io/en/latest/api.html#discord.File
+        """
+        # import moved to avoid circular import
+        from .parser import SlackParser
+
+        file = MessageFile(
+            id=file_dict.get('id'),
+            name=file_dict.get('name'),
+            url=SlackParser.unescape_url(file_dict.get('url_private')),
+        )
+
+        if logger.level == logging.DEBUG:
+            logger.debug(f"File added to parsed message: {file}")
+        else:
+            logger.info(f"File added to parsed message: {file.name}")
+
+        self.files.append(file)
+
     def __repr__(self):
-        return f"ParsedMessage(text='{self.text}', links='{self.links})"
+        return f"ParsedMessage(text='{self.text}', links={self.links}, files={self.files})"
 
     def get_discord_send_kwargs(self):
         """
@@ -129,10 +171,27 @@ class MessageLink():
         self.thumb_url = thumb_url
 
     def __repr__(self):
-        return (f"MessageLink(title='{self.title}',"
-                f" title_link='{self.title_link}',"
-                f" text='{self.text}',"
-                f" service_name='{self.service_name}',"
-                f" service_icon='{self.service_icon}',"
-                f" image_url='{self.image_url}',"
-                f" thumb_url='{self.thumb_url}')")
+        return (f"MessageLink(title='{ParsedMessage.str_or_none(self.title)}',"
+                f" title_link='{ParsedMessage.str_or_none(self.title_link)}',"
+                f" text='{ParsedMessage.str_or_none(self.text)}',"
+                f" service_name='{ParsedMessage.str_or_none(self.service_name)}',"
+                f" service_icon='{ParsedMessage.str_or_none(self.service_icon)}',"
+                f" image_url='{ParsedMessage.str_or_none(self.image_url)}',"
+                f" thumb_url='{ParsedMessage.str_or_none(self.thumb_url)}')")
+
+class MessageFile():
+    """
+    Properties from an exported Slack message to support an attached file
+    """
+    def __init__(self, id, name, url):
+        self.id = id      # from slack
+        self.name = name
+        self.url = url    # url_private in slack
+        # This will be set later, when the file is downloaded
+        self.local_filename = None
+
+    def __repr__(self):
+        return (f"MessageFile(id='{self.id}',"
+                f" name='{self.name}'"
+                f" url='{self.url}'"
+                f" local_filename={ParsedMessage.str_or_none(self.local_filename)})")

--- a/slack2discord/message.py
+++ b/slack2discord/message.py
@@ -109,6 +109,7 @@ class ParsedMessage():
         For more details, see:
         https://discordpy.readthedocs.io/en/latest/api.html#discord.TextChannel.send
         https://discordpy.readthedocs.io/en/latest/api.html#discord.Thread.send
+        https://discordpy.readthedocs.io/en/latest/api.html#discord.Embed
         """
         if self.links:
             if len(self.links) > MAX_DISCORD_EMBEDS:
@@ -145,6 +146,28 @@ class ParsedMessage():
             'embeds': embeds,
         }
 
+    def get_discord_add_files_args(self):
+        """
+        Return the list of MessageFile objects within a ParsedMessage object as a Discord
+        specific list of args
+
+        This can be passed via the method Messsage.add_files(*files), assuming the caller has
+        a Discord Message object
+
+        If there are no files, return None
+
+        For more details, see:
+        https://discordpy.readthedocs.io/en/latest/api.html#discord.Message.add_files
+        https://discordpy.readthedocs.io/en/latest/api.html#discord.File
+        """
+        if not self.files:
+            return None
+
+        return [discord.File(file.local_filename,  # this is the actual file to upload
+                             filename=file.name)   # this is what Discord should call the file
+                for file in self.files]
+
+
 class MessageLink():
     """
     Properties from an exported Slack message to support a link
@@ -178,6 +201,7 @@ class MessageLink():
                 f" service_icon='{ParsedMessage.str_or_none(self.service_icon)}',"
                 f" image_url='{ParsedMessage.str_or_none(self.image_url)}',"
                 f" thumb_url='{ParsedMessage.str_or_none(self.thumb_url)}')")
+
 
 class MessageFile():
     """

--- a/slack2discord/parser.py
+++ b/slack2discord/parser.py
@@ -267,10 +267,10 @@ class SlackParser():
         The values are dicts, where:
         - the keys are the timestamps of the slack messages
         - the values are tuples of length 2
-          - the first item is the formatted string of a message ready to post to discord
+          - the first item is a ParsedMessage object
           - the second item is a dict if this message has a thread, otherwise None.
             - the keys are the timestamps of the messages within the thread
-            - the values are the formatted strings of the messages within the thread
+            - the values are a list of ParsedMessage objects
 
         Does not return anything, the results populate the class member self.parsed_messages
         """

--- a/slack2discord/parser.py
+++ b/slack2discord/parser.py
@@ -389,9 +389,14 @@ class SlackParser():
                     message.get('text', ""))))
         full_message_text = SlackParser.format_message(timestamp, name, message_text)
         parsed_message = ParsedMessage(full_message_text)
+
         if 'attachments' in message:
             for attachment in message['attachments']:
                 parsed_message.add_link(attachment)
+
+        if 'files' in message:
+            for file in message['files']:
+                parsed_message.add_file(file)
 
         if 'replies' in message:
             # this is the head of a thread


### PR DESCRIPTION
Files are accounted for during parsing with a list of (new) MessageFile objects added to ParsedMessage objects.

A new step is added between parsing and running the Discord client, which is to download all of the files from Slack to the local filesystem via the (new) SlackDownloader (see downloader.py). Files by default go to a uniquely named timestamp dir (to second level accuracy) in a subdir of a `downloads` subdir relative to the slack2discord.py script. This can be overridden with a new optional arg, `--downloads_dir`.

This introduces a new library dependency, requests.

The downloads all happen serially, in a blocking manner. This could be made faster using aiohttp to do asynchronous downloading of multiple files simultaneously, but that is way out of the current scope.

Messages with attached files (whether or not there is any message text present) appear to empirically lack sufficient information for us to properly get the poster's name via the JSON representing just the message. (See SlackParser.get_name()) We end up falling back to the `user` property, which is just a user id from which we strip the leading `U`. This is okay for now, but less than ideal. A better plan would be to use the file `users.json` in the top level of the Slack export to look up user name info based on Slack user id. This will come next, but is out of the current scope.