### PR TITLE
Get primary user information from `users.json` file, if possible

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Current releases, on [this fork](https://github.com/richfromm/slack2discord)
 
-### 2.5 (in progress)
+### 2.5
 
 * Add support for files attached to messages
     * Files are downloaded from Slack then uploaded to Discord and
@@ -10,6 +10,14 @@
     * Add optional `--downloads-dir DOWNLOADS_DIR` command line argument
         * Defaults to a newly created dir of the form
           `./downloads/<timestamp>` relative to the location of the script.
+* Get primary user information from `users.json` file, if possible
+    * Previously, user information was retrieved from within each
+      message. Now that is a fallback.
+    * The problem was that messages with attached files do not have
+      this information.
+    * File is at the top level of the Slack export. Default is to
+      deduce location based on other existing parameters. Can also set
+      with optional `--users-file USERS_FILE` command line argument.
 
 ### 2.4
 

--- a/slack2discord.py
+++ b/slack2discord.py
@@ -37,6 +37,7 @@ if __name__ == '__main__':
         dest_channel=config.dest_channel,
         src_dirtree=config.src_dirtree,
         channel_file=config.channel_file,
+        users_file=config.users_file,
         verbose=config.verbose,
     )
     parser.parse()

--- a/slack2discord/config.py
+++ b/slack2discord/config.py
@@ -16,7 +16,8 @@ DESCRIPTION = dedent(
 
 USAGE = dedent(
     f"""
-    {argv[0]} [--token TOKEN] [--server SERVER] [--create] [--downloads-dir DOWNLOADS_DIR] \\
+    {argv[0]} [--token TOKEN] [--server SERVER] [--create] \\
+        [--users-file USERS_FILE] [--downloads-dir DOWNLOADS_DIR] \\
         [-v | --verbose] [-n | --dry-run] <src-and-dest-related-options>
 
     src and dest related options must follow one of the following mutually exclusive formats:
@@ -196,6 +197,17 @@ def get_config(argv):
                         default=None,
                         help="File containing list of Slack channels to port to Discord, with"
                         " optional mapping to Discord channels if named differently.")
+
+    parser.add_argument('--users-file',
+                        required=False,
+                        default=None,
+                        help="JSON file to obtain Slack user name information. If not present,"
+                        " will default to 'users.json' in the dir at the top level of the Slack"
+                        " export, which in turn is deduced from SRC_FILE or SRC_DIR or SRC_DIRTREE"
+                        " as applicable. If not specified and unable to deduce, or not found,"
+                        " Slack user name information will be fetched from individual messages."
+                        " This generally is fine. (So far, messages with attached files are the"
+                        " only known case in which this alternate method fails.")
 
     parser.add_argument('--downloads-dir',
                         required=False,


### PR DESCRIPTION
* Previously, user information was retrieved from within each message. Now that is a fallback.

* The problem was that messages with attached files do not have this information.

* File is at the top level of the Slack export. Default is to deduce location based on other existing parameters. Can also set with optional `--users-file USERS_FILE` command line argument.