### PR TITLE
Ensure deleted files aren't added to messages

### DIFF
--- a/slack2discord/parser.py
+++ b/slack2discord/parser.py
@@ -477,7 +477,16 @@ class SlackParser():
 
         if 'files' in message:
             for file in message['files']:
-                if file['mode'] != 'tombstone':
+                if file.get('mode') == 'tombstone':
+                    # File was deleted from Slack, just log this,
+                    # don't bother mentioning this state in the Discord import.
+                    if 'date_deleted' in file:
+                        logger.warning("Attached file was deleted at"
+                                       f" {SlackParser.format_time(file['date_deleted'])}. Ignoring.")
+                    else:
+                        logger.warning(f"Attached file was deleted. Ignoring.")
+                else:
+                    # Normal attached file case
                     parsed_message.add_file(file)
 
         if 'replies' in message:

--- a/slack2discord/parser.py
+++ b/slack2discord/parser.py
@@ -477,7 +477,8 @@ class SlackParser():
 
         if 'files' in message:
             for file in message['files']:
-                parsed_message.add_file(file)
+                if file['mode'] != 'tombstone':
+                    parsed_message.add_file(file)
 
         if 'replies' in message:
             # this is the head of a thread


### PR DESCRIPTION
Although this seems(?) to be undocumented behavior on Slack's part, I noticed in our own backups that files may not necessarily have a `url_private` attribute. These are denoted with `"mode": "tombstone"`, which (I assume) means that they were deleted. I found an example [here](https://github.com/zulip/zulip/issues/11619#issuecomment-467052478) of someone else encountering the same thing. Mine looked something like this:
```json
"type": "message",
"text": "...",
"files": [
    {
        "id": "F023WGH1WF7",
        "mode": "tombstone"
    }
],
"upload": false,
"user": "...",
"display_as_bot": false,
"ts": "1622764865.023000"
```

Without this change, `SlackDownloader.download` would fail on those files, since they doesn't have a URL associated with them. However, I added a line in `SlackParser.parse_message` that checks for this, and doesn't call `ParsedMessage.add_file` if this is the case.

Hope this helps, and thanks for all of your great work!