### PR TITLE
Add --ignore-file-not-found option to ignore HTTP not found errors downloading file attachments from Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,8 @@ following manners. This is the order that is searched:
 
 Briefly, the script is executed via:
 
-    ./slack2discord.py [--token TOKEN] [--server SERVER] [--create] [--downloads-dir DOWNLOADS_DIR] \
+    ./slack2discord.py [--token TOKEN] [--server SERVER] [--create] \
+        [--users-file USERS_FILE] [--downloads-dir DOWNLOADS_DIR] [--ignore-file-not-found] \
         [-v | --verbose] [-n | --dry-run] <src-and-dest-related-options>
 
 The src and dest related options can be specified in one of three different
@@ -210,6 +211,41 @@ For more details, and complete descriptions of all command line
 options, execute:
 
     ./slack2discord.py --help
+
+## File attachments
+
+As noted at the end of [Slack: How to read Slack data exports], files uploaded
+to Slack are not directly part of a Slack export. Instead, the export contains
+URLs that point to the locations of the files on Slack servers. These URLs
+include a token that gives you the ability access those files. These tokens
+are listed along with the exports on your Slack workspace's export page, which
+can be found at `https://<workspace-name>.slack.com/services/export`
+
+When running the script, such files will first be downloaded from Slack to a
+local dir (which can be controlled with the `--downloads-dir` option), and
+then uploaded to Discord. There are a number of reasons why this operation
+could fail, and the files listed in the Slack export might not be found. These
+include:
+
+* The file was deleted from Slack after the export was performed
+
+* The download token associated with that file export was revoked (this can be
+  done via the export page for the Slack workspace)
+
+In these cases (and for any other HTTP errors related to downloading file
+attachments from Slack), the default behavior is for the script to fail by
+raising an HTTPError. This allows you to investigate the situation before
+deciding how to proceed.
+
+For the special case of HTTP Not Found errors, you can override this behavior,
+and simply log the not found file as a warning, with the command line option
+`--ignore-file-not-found`.
+
+Note that if any files are deleted before the export is created, this state
+will be reflected within the export (the file will have its `mode` set to
+`tombstone`). Any such files will always be logged as warnings and ignored,
+regardless of whether or not the ignore option is set for the HTTP Not found
+case.
 
 ## Internals
 

--- a/slack2discord.py
+++ b/slack2discord.py
@@ -45,6 +45,7 @@ if __name__ == '__main__':
     downloader = SlackDownloader(
         parsed_messages=parser.parsed_messages,
         downloads_dir=config.downloads_dir,
+        ignore_not_found=config.ignore_file_not_found,
     )
     downloader.download()
 

--- a/slack2discord/config.py
+++ b/slack2discord/config.py
@@ -17,7 +17,7 @@ DESCRIPTION = dedent(
 USAGE = dedent(
     f"""
     {argv[0]} [--token TOKEN] [--server SERVER] [--create] \\
-        [--users-file USERS_FILE] [--downloads-dir DOWNLOADS_DIR] \\
+        [--users-file USERS_FILE] [--downloads-dir DOWNLOADS_DIR] [--ignore-file-not-found] \\
         [-v | --verbose] [-n | --dry-run] <src-and-dest-related-options>
 
     src and dest related options must follow one of the following mutually exclusive formats:
@@ -218,6 +218,17 @@ def get_config(argv):
                         " location of this script. Unless resuming from a previously failed script"
                         " execution, it is highly recommended that each execution of the script"
                         " use a unique directory.")
+
+    parser.add_argument('--ignore-file-not-found',
+                        required=False,
+                        action='store_true',
+                        help="Ignore HTTP Not Found errors when downloading attached files. The"
+                        " default behavior is to fail by raising an HTTPError on any HTTP errors"
+                        " related to downloading file attachments from Slack. Use this option to"
+                        " ignore errors of files not found, and log as warnings. This state can"
+                        " occur if a user deletes a file from Slack after performing the export."
+                        " Note that files deleted before the export are automatically logged as"
+                        " warnings and ignored, regardless of this option.")
 
     parser.add_argument('-v', '--verbose',
                         required=False,

--- a/slack2discord/downloader.py
+++ b/slack2discord/downloader.py
@@ -45,9 +45,7 @@ class SlackDownloader():
         # (if parsing includes any files)
         self.downloads_dir = downloads_dir
 
-        # XXX FOR TESTING ONLY !!!
-        self.ignore_not_found = True
-        # self.ignore_not_found = ignore_not_found
+        self.ignore_not_found = ignore_not_found
 
         self.files: list[MessageFile] = []
 

--- a/slack2discord/message.py
+++ b/slack2discord/message.py
@@ -154,6 +154,8 @@ class ParsedMessage():
         This can be passed via the method Messsage.add_files(*files), assuming the caller has
         a Discord Message object
 
+        Any files which were not found and previously ignored are excluded
+
         If there are no files, return None
 
         For more details, see:
@@ -165,7 +167,8 @@ class ParsedMessage():
 
         return [discord.File(file.local_filename,  # this is the actual file to upload
                              filename=file.name)   # this is what Discord should call the file
-                for file in self.files]
+                for file in self.files
+                if not file.not_found]             # exclude files not found
 
 
 class MessageLink():
@@ -211,11 +214,15 @@ class MessageFile():
         self.id = id      # from slack
         self.name = name
         self.url = url    # url_private in slack
-        # This will be set later, when the file is downloaded
+        # This will be set later, when the file is downloaded (successfully or not)
         self.local_filename = None
+        # This is set in the special case of the file not found,
+        # which the user can optionally ignore.
+        self.not_found = False
 
     def __repr__(self):
         return (f"MessageFile(id='{self.id}',"
-                f" name='{self.name}'"
-                f" url='{self.url}'"
-                f" local_filename={ParsedMessage.str_or_none(self.local_filename)})")
+                f" name='{self.name}',"
+                f" url='{self.url}',"
+                f" local_filename={ParsedMessage.str_or_none(self.local_filename)}),"
+                f" not_found={self.not_found})")


### PR DESCRIPTION
This is a replacement for https://github.com/richfromm/slack2discord/pull/21 . Not all attachments are images, so I have decided to not substitute not found files with a fallback image.

Instead, provide the option to deal with the situation in a manner similar to https://github.com/richfromm/slack2discord/pull/20, that concerns files deleted from Slack before doing the export. In that case, we simply log a warning and continue.

This is potentially a more severe situation, so we want to give the user the ability to investigate further. The default behavior therefore stays as before, we raise an HTTPError after the failed download via `raise_for_status()`. But give a somewhat more meaningful error msg, including pointing out to the user that they can override this behavior (and achieve similar behavior to the deleted file case) via the command line option `--ignore-file-not-found`.

I have identified and replicated two situations in which this scenario can occur:
* The file was is from Slack after the export
* The download token associated with the file export is revoked
