### PR TITLE
Allow for re-use of downloaded files

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,13 @@ a `.py` suffix included in the package name_)
 * `requests` ([docs](https://requests.readthedocs.io/en/latest/),
 [pypi](https://pypi.org/project/requests/),
 [source](https://github.com/psf/requests))
+* `tqdm` ([docs](https://tqdm.github.io/),
+[pypi](https://pypi.org/project/tqdm/),
+[source](https://github.com/tqdm/tqdm))
 
 via:
 
-    pip install discord.py decorator requests
+    pip install discord.py decorator requests tqdm
 
 For help creating virtual environments, see the
 [venv](https://docs.python.org/3/library/venv.html) docs. If you use Python a

--- a/slack2discord.pyv
+++ b/slack2discord.pyv
@@ -1,3 +1,4 @@
 discord.py
 decorator
 requests
+tqdm

--- a/slack2discord/config.py
+++ b/slack2discord/config.py
@@ -215,9 +215,11 @@ def get_config(argv):
                         help="Directory in which to download any files attached to Slack messages,"
                         " before uploading them to Discord. If not present, will default to a"
                         " newly created dir of the form './downloads/<timestamp>', relative to the"
-                        " location of this script. Unless resuming from a previously failed script"
-                        " execution, it is highly recommended that each execution of the script"
-                        " use a unique directory.")
+                        " location of this script. Existing files in an existing dir will be"
+                        " re-used if the file size matches the remote. Unless resuming from a"
+                        " previously failed script execution, or executing for real after a dry"
+                        " run, it is recommended that each execution of the script use a unique"
+                        " directory.")
 
     parser.add_argument('--ignore-file-not-found',
                         required=False,

--- a/slack2discord/downloader.py
+++ b/slack2discord/downloader.py
@@ -104,7 +104,7 @@ class SlackDownloader():
 
             return int(size)
 
-    def _wget(self, url, filename, ignore_not_found = False) -> None:
+    def _wget(self, url, filename, ignore_not_found = False) -> bool:
         """
         Fetch a file via HTTP GET from the given URL, and store it in the local filename.
 
@@ -130,10 +130,10 @@ class SlackDownloader():
         if exists(filename):
             logger.warning(f"local filename already exists, will overwrite: {filename}")
 
-        with get(url) as req:
+        with get(url) as resp:
             # Special case 404 errors, allowing user to ignore.
             # All other HTTP errors raise an exception and fail.
-            if req.status_code == codes.not_found:
+            if resp.status_code == codes.not_found:
                 if ignore_not_found:
                     logger.warning(f"Not found error returned fetching {url} to {filename}, ignoring.")
                     return False
@@ -141,9 +141,9 @@ class SlackDownloader():
                              " You can ignore all of these with --ignore-file-not-found")
                 # intentional fall through, since we **do** want to raise the error next
 
-            req.raise_for_status()
+            resp.raise_for_status()
             with open(filename, 'wb') as file:
-                file.write(req.content)
+                file.write(resp.content)
 
         return True
 

--- a/slack2discord/downloader.py
+++ b/slack2discord/downloader.py
@@ -139,7 +139,9 @@ class SlackDownloader():
                     logger.warning(f"Not found error returned fetching {url} to {filename}, ignoring.")
                     return False
                 logger.error(f"Not found error returned fetching {url} to {filename}."
-                             " You can ignore all of these with --ignore-file-not-found")
+                             ' You can ignore all of these with "--ignore-file-not-found".')
+                logger.info("If you wish to resume and re-use existing successfully downloaded"
+                            f' files, you can also specify "--downloads-dir {self.downloads_dir}"')
                 # intentional fall through, since we **do** want to raise the error next
 
             resp.raise_for_status()

--- a/slack2discord/downloader.py
+++ b/slack2discord/downloader.py
@@ -1,9 +1,10 @@
 import logging
 from os import makedirs
-from os.path import dirname, exists, isdir, join, realpath
+from os.path import dirname, exists, getsize, isdir, isfile, join, realpath
 from time import time
+from typing import Optional
 
-from requests import codes, get
+from requests import codes, get, head
 
 from .message import ParsedMessage, MessageFile
 
@@ -83,6 +84,26 @@ class SlackDownloader():
                     for thread_message in thread.values():
                         self._add_files(thread_message)
 
+    def _getsize_remote(self, url) -> Optional[int]:
+        """
+        Return the size of a remote file (assuming that's what's located at the specified HTTP
+        URL), in bytes, via the Content-Length HTTP header.  If we are unable to do so, for
+        whatever reason, return None
+        """
+        with head(url) as resp:
+            if not resp.ok:
+                logger.warning(
+                    f"Unable to get size of remote URL {url} (HTTP response not OK)")
+                return None
+
+            size = resp.headers.get('Content-Length')
+            if size is None:
+                logger.warning(
+                    f"Unable to get size of remote URL {url} (missing Content-Length header)")
+                return None
+
+            return int(size)
+
     def _wget(self, url, filename, ignore_not_found = False) -> None:
         """
         Fetch a file via HTTP GET from the given URL, and store it in the local filename.
@@ -147,19 +168,32 @@ class SlackDownloader():
 
         success = 0
         not_found = 0
+        skipped = 0
         for file in self.files:
             # using file.name would be more descriptive
             # but that risks filename collisions
             # we could place each file in its own dir, e.g. self.downloads_dir/file.id/file.name
             # but that would be more awkward to work with
             file.local_filename = join(self.downloads_dir, file.id)
+
+            # don't download the file if it already exists and the size has not changed
+            if isfile(file.local_filename):
+                local_size = getsize(file.local_filename)
+                remote_size = self._getsize_remote(file.url)
+                if remote_size and (local_size == remote_size):
+                   logger.info(f"Skipping URL {file.url} which is covered by already existing"
+                               f" {local_size} byte local file {file.local_filename}")
+                   skipped += 1
+                   continue
+
             if self._wget(file.url, file.local_filename, self.ignore_not_found):
                 success += 1
             else:
                 file.not_found = True
                 not_found += 1
 
-        assert success + not_found == len(self.files)
+        assert success + not_found + skipped == len(self.files)
         logger.info(f"Successfully downloaded {success} files to {self.downloads_dir}")
+        logger.info(f"Skipped {skipped} files that already existed locally")
         if not_found > 0:
             logger.warning(f"Ignored {not_found} files not found")

--- a/slack2discord/downloader.py
+++ b/slack2discord/downloader.py
@@ -5,6 +5,7 @@ from time import time
 from typing import Optional
 
 from requests import codes, get, head
+from tqdm import tqdm
 
 from .message import ParsedMessage, MessageFile
 
@@ -36,7 +37,7 @@ class SlackDownloader():
         logger.info(f"Downloaded files from Slack (if any) will be placed in {downloads_dir}")
         if exists(downloads_dir):
             if isdir(downloads_dir):
-                logger.warn(f"Downloads dir already exists: {downloads_dir}")
+                logger.info(f"Downloads dir already exists: {downloads_dir}")
             else:
                 error_msg = f"Downloads dir already exists but is **NOT** a dir: {downloads_dir}"
                 logger.error(error_msg)
@@ -169,7 +170,7 @@ class SlackDownloader():
         success = 0
         not_found = 0
         skipped = 0
-        for file in self.files:
+        for file in tqdm(self.files):
             # using file.name would be more descriptive
             # but that risks filename collisions
             # we could place each file in its own dir, e.g. self.downloads_dir/file.id/file.name
@@ -181,8 +182,8 @@ class SlackDownloader():
                 local_size = getsize(file.local_filename)
                 remote_size = self._getsize_remote(file.url)
                 if remote_size and (local_size == remote_size):
-                   logger.info(f"Skipping URL {file.url} which is covered by already existing"
-                               f" {local_size} byte local file {file.local_filename}")
+                   logger.debug(f"Skipping URL {file.url} which is covered by already existing"
+                                f" {local_size} byte local file {file.local_filename}")
                    skipped += 1
                    continue
 


### PR DESCRIPTION
Previously, even if you specified an existing directory with `--downloads-dir`, the file would always be freshly downloaded.

Now do **not** do this, and re-use the existing file, as long as a file exists with the same name, and the file size matches the `Content-Length` HTTP response header.

Also wrap the downloads in a progress bar with tqdm

https://github.com/richfromm/slack2discord/issues/26