### PR TITLE
Validate Discord channel names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@
 * Change default behavior to automatically create missing Discord channels
   ([issue#23](https://github.com/richfromm/slack2discord/issues/23))
     * Former option `--create` is now `--no-create`
+* Validate Discord channel names
+  ([issue#24](https://github.com/richfromm/slack2discord/issues/24))
+* Begin adding automated tests, via pytest
+    * These also run automatically in GitHub
 
 ### 2.7
 

--- a/README.md
+++ b/README.md
@@ -303,8 +303,13 @@ the required dev packages into your virtualenv:
 
     pip install -r requirements-dev.txt
 
-This will allow you to run
-[mypy](https://mypy.readthedocs.io/en/stable/) static typing checks:
+This will allow you to run automated tests via
+[pytest](https://docs.pytest.org/en/latest/):
+
+    pytest
+
+As well as [mypy](https://mypy.readthedocs.io/en/stable/) static
+typing checks:
 
     mypy slack2discord.py
 
@@ -318,7 +323,7 @@ checks:
 
     flake8 slack2discord.py slack2discord
 
-You can automatically run both checks with `./check.sh`. GitHub is configured
+You can automatically run all checks with `./check.sh`. GitHub is configured
 (via `.github/workflows/check.yaml` and [GitHub
 Actions](https://docs.github.com/en/actions)) to automatically run these checks
 on any PRs, to require the checks to pass before merging to `master`, and to
@@ -331,7 +336,7 @@ Some items I am considering:
 * Better error reporting, so that if an entire import is not
   successful, it is easier to resume in a way as to avoid duplicates.
 
-* Add unit tests
+* Add more automated tests
 
 * Ways to optimize file downloads:
     * Download multiple files asynchronously via using

--- a/check.sh
+++ b/check.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
 # this assumes that all project dependencies, as well as all dev dependencies
-# (e.g. flake8 and mypy) have already been installed, e.g. via:
+# (e.g. flake8, mypy, and pytest) have already been installed, e.g. via:
 #    pip install -r requrements.txt
 #    pip install -r requrements-dev.txt
 
 # flake8 and mypy config options are specified in setup.cfg
+# (pytest can be as well, although there is not yet any pytest non-default config)
 
 # colored output: https://www.tutorialspoint.com/how-to-output-colored-text-to-a-linux-terminal
 red="\033[1;31m"
@@ -37,6 +38,18 @@ if [[ $mypy_result -eq 0 ]]; then
    echo -e "mypy: $pass"
 else
    echo -e "mypy: $fail"
+   check_result=1
+fi
+
+echo
+echo "Run pytest tests"
+echo "pytest"
+pytest
+pytest_result=$?
+if [[ $pytest_result -eq 0 ]]; then
+   echo -e "pytest: $pass"
+else
+   echo -e "pytest: $fail"
    check_result=1
 fi
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-nose2
+pytest
 mypy
 types-decorator
 types-requests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+nose2
 mypy
 types-decorator
 types-requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,7 @@ show_error_codes = True
 
 [flake8]
 max-line-length = 99
+
+# pytest can be configured here via [tool:pytest]
+# although it is not recommended:
+# https://docs.pytest.org/en/latest/reference/customize.html#setup-cfg

--- a/slack2discord/tests/test_client.py
+++ b/slack2discord/tests/test_client.py
@@ -1,8 +1,6 @@
-from unittest import TestCase
-
 from ..client import DiscordClient
 
-class TestDiscordClient(TestCase):
+class TestDiscordClient():
 
     def test_valid_channel_name(self):
         """
@@ -25,7 +23,7 @@ class TestDiscordClient(TestCase):
             "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890",
         ]
         for channel_name in channel_names:
-            self.assertTrue(DiscordClient.valid_channel_name(channel_name))
+            assert DiscordClient.valid_channel_name(channel_name)
 
     def test_invalid_channel_name(self):
         """
@@ -38,4 +36,4 @@ class TestDiscordClient(TestCase):
             "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901",
         ]
         for channel_name in channel_names:
-            self.assertFalse(DiscordClient.valid_channel_name(channel_name))
+            assert not DiscordClient.valid_channel_name(channel_name)

--- a/slack2discord/tests/test_client.py
+++ b/slack2discord/tests/test_client.py
@@ -1,0 +1,41 @@
+from unittest import TestCase
+
+from ..client import DiscordClient
+
+class TestDiscordClient(TestCase):
+
+    def test_valid_channel_name(self):
+        """
+        Test Discord channel names that pass validation
+        """
+        channel_names = [
+            "general",
+            "foo-bar",
+            "foo_bar",
+            "foo-_bar",
+            "foo_-bar",
+            "foo__bar",
+            "foo-_-bar",
+            "foo-bar-baz",
+            "foo_bar_baz",
+            "foo-bar_baz",
+            "foo_bar-baz",
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890-_",
+            "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
+            "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890",
+        ]
+        for channel_name in channel_names:
+            self.assertTrue(DiscordClient.valid_channel_name(channel_name))
+
+    def test_invalid_channel_name(self):
+        """
+        Test Discord channel names that fail validation
+        """
+        channel_names = [
+            "foo--bar",
+            "",
+            "foo#bar",
+            "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901",
+        ]
+        for channel_name in channel_names:
+            self.assertFalse(DiscordClient.valid_channel_name(channel_name))

--- a/slack2discord/tests/test_client.py
+++ b/slack2discord/tests/test_client.py
@@ -1,40 +1,39 @@
+import pytest
+
 from ..client import DiscordClient
 
 
 class TestDiscordClient():
-
-    def test_valid_channel_name(self):
+    @pytest.mark.parametrize("channel_name", [
+        "general",
+        "foo-bar",
+        "foo_bar",
+        "foo-_bar",
+        "foo_-bar",
+        "foo__bar",
+        "foo-_-bar",
+        "foo-bar-baz",
+        "foo_bar_baz",
+        "foo-bar_baz",
+        "foo_bar-baz",
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890-_",
+        "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",  # noqa: E501
+        "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890",  # noqa: E501
+    ])
+    def test_valid_channel_name(self, channel_name):
         """
         Test Discord channel names that pass validation
         """
-        channel_names = [
-            "general",
-            "foo-bar",
-            "foo_bar",
-            "foo-_bar",
-            "foo_-bar",
-            "foo__bar",
-            "foo-_-bar",
-            "foo-bar-baz",
-            "foo_bar_baz",
-            "foo-bar_baz",
-            "foo_bar-baz",
-            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890-_",
-            "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",  # noqa: E501
-            "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890",  # noqa: E501
-        ]
-        for channel_name in channel_names:
-            assert DiscordClient.valid_channel_name(channel_name)
+        assert DiscordClient.valid_channel_name(channel_name)
 
-    def test_invalid_channel_name(self):
+    @pytest.mark.parametrize("channel_name", [
+        "foo--bar",
+        "",
+        "foo#bar",
+        "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901",  # noqa: E501
+    ])
+    def test_invalid_channel_name(self, channel_name):
         """
         Test Discord channel names that fail validation
         """
-        channel_names = [
-            "foo--bar",
-            "",
-            "foo#bar",
-            "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901",  # noqa: E501
-        ]
-        for channel_name in channel_names:
-            assert not DiscordClient.valid_channel_name(channel_name)
+        assert not DiscordClient.valid_channel_name(channel_name)

--- a/slack2discord/tests/test_client.py
+++ b/slack2discord/tests/test_client.py
@@ -1,5 +1,6 @@
 from ..client import DiscordClient
 
+
 class TestDiscordClient():
 
     def test_valid_channel_name(self):
@@ -19,8 +20,8 @@ class TestDiscordClient():
             "foo-bar_baz",
             "foo_bar-baz",
             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890-_",
-            "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",
-            "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890",
+            "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",  # noqa: E501
+            "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890",  # noqa: E501
         ]
         for channel_name in channel_names:
             assert DiscordClient.valid_channel_name(channel_name)
@@ -33,7 +34,7 @@ class TestDiscordClient():
             "foo--bar",
             "",
             "foo#bar",
-            "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901",
+            "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901",  # noqa: E501
         ]
         for channel_name in channel_names:
             assert not DiscordClient.valid_channel_name(channel_name)

--- a/slack2discord/tests/test_client.py
+++ b/slack2discord/tests/test_client.py
@@ -12,10 +12,12 @@ class TestDiscordClient():
         "foo_-bar",
         "foo__bar",
         "foo-_-bar",
+        "foo_-_bar",
         "foo-bar-baz",
         "foo_bar_baz",
         "foo-bar_baz",
         "foo_bar-baz",
+        "a",
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890-_",
         "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789",  # noqa: E501
         "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890",  # noqa: E501
@@ -28,8 +30,17 @@ class TestDiscordClient():
 
     @pytest.mark.parametrize("channel_name", [
         "foo--bar",
+        "foo---bar",
+        "foo----bar",
         "",
+        " ",
+        "foo bar",
+        "foo	bar",
         "foo#bar",
+        "foo`-=bar",
+        "foo~!@#$%^&*()_+bar",
+        r"foo[]\;',./bar",  # don't want the backslash to be treated as an escape
+        'foo{}|:"<>?bar',
         "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901",  # noqa: E501
     ])
     def test_invalid_channel_name(self, channel_name):


### PR DESCRIPTION
The following criteria must be met:
* Names must contain only alphanumeric, dash (-), and/or underscore (_) characters
* Length must be between 1 and 100 chars (inclusive)
* Multiple dashes in a row (e.g. --) are not permitted

The actual reality of Discord channel creation is a bit more complex. Empirically, there
are numerous (undocumented?) cases where an input channel name does **not** fail to create
a channel, but the channel created does not have precisely the same name as the input. For
example:
* Multiple dashes in a row are converted into a single dash
* Space and tilde are converted to dash
* Tab and newline are removed
* All other symbols are removed

For our purposes, this is too complex to deal with, and we will fail to validate any input
that does not result in creating a channel with the same name as the input.

https://github.com/richfromm/slack2discord/issues/24
